### PR TITLE
When first proconnect login, update threepid email if needed

### DIFF
--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -7,8 +7,9 @@ from synapse.module_api import ModuleApi
 
 logger = logging.getLogger(__name__)
 
-class LoginListener(object):
-    """Implementation of the 
+class LoginCallback(object):
+    """
+    Implementation of a Login Callback
     """
 
     def __init__(
@@ -32,6 +33,10 @@ class LoginListener(object):
     ) -> None:
         logger.info("onLogin callback %s, %s, %s", user_id, auth_provider_type, auth_provider_id)
 
+        # only process login from oidc-proconnect
+        if auth_provider_id != "oidc-proconnect":
+            return
+
         # Extra attributes are set by the mapper : ./proconnect_mapping.py
         # This mapper is only invoked when the oidc user is not mapped to a MxId
         # After the first login the oidc user unique field (sub) is mapped to a MxId
@@ -39,7 +44,7 @@ class LoginListener(object):
         sso_extra_attributes = self.module_api._auth_handler._extra_attributes.get(user_id, None)
         logger.info("extra attributes found for user %s : %s",user_id, sso_extra_attributes or "nothing")
 
-        if auth_provider_id == "oidc-proconnect" and sso_extra_attributes:
+        if sso_extra_attributes:
             #check if extra attributes were attached to user_id 
             extra_attributes = sso_extra_attributes.extra_attributes
             oidc_email = extra_attributes.get('oidc_email', None)

--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -32,12 +32,12 @@ class LoginListener(object):
     ) -> None:
         logger.info("onLogin callback %s, %s, %s", user_id, auth_provider_type, auth_provider_id)
 
-        extra_attributes = self.module_api._auth_handler._extra_attributes.get(user_id)
+        sso_extra_attributes = self.module_api._auth_handler._extra_attributes.get(user_id, None)
         logger.info("extra attributes found for user %s : %s",user_id, extra_attributes or "nothing")
 
-        if auth_provider_id == "proconnect" and extra_attributes:
+        if auth_provider_id == "oidc-proconnect" and sso_extra_attributes:
             #check if extra attributes were attached to user_id 
-            extra_attributes = self.module_api._auth_handler._extra_attributes[user_id]
+            extra_attributes = sso_extra_attributes.extra_attributes
             oidc_email = extra_attributes.get('oidc_email', None)
             known_email = extra_attributes.get('known_email', None)
             if(known_email and oidc_email and known_email != oidc_email):

--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -32,7 +32,7 @@ class LoginListener(object):
     ) -> None:
         logger.info("onLogin callback %s, %s, %s", user_id, auth_provider_type, auth_provider_id)
 
-        extra_attributes = self.module_api._auth_handler._extra_attributes[user_id]
+        extra_attributes = self.module_api._auth_handler._extra_attributes.get(user_id)
         logger.info("extra attributes found for user %s : %s",user_id, extra_attributes or "nothing")
 
         if auth_provider_id == "proconnect" and extra_attributes:

--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -41,17 +41,20 @@ class LoginCallback(object):
         # This mapper is only invoked when the oidc user is not mapped to a MxId
         # After the first login the oidc user unique field (sub) is mapped to a MxId
         # Thus the 3PID substitution happens only at the first login of the oidc user
-        sso_extra_attributes = self.module_api._auth_handler._extra_attributes.get(user_id, None)
-        logger.info("extra attributes found for user %s : %s",user_id, sso_extra_attributes or "nothing")
 
-        if sso_extra_attributes:
-            #check if extra attributes were attached to user_id 
-            extra_attributes = sso_extra_attributes.extra_attributes
-            oidc_email = extra_attributes.get('oidc_email', None)
-            current_threepid_email = extra_attributes.get('current_threepid_email', None)
-            if(current_threepid_email and oidc_email and current_threepid_email != oidc_email):
-                # make the substitution
-                await self.substitute_threepid(user_id, current_threepid_email, oidc_email)
+        # Check if extra attributes were attached to user_id 
+        sso_extra_attributes = self.module_api._auth_handler._extra_attributes.get(user_id, None)
+        logger.info("extra attributes found for user %s : %s",user_id, sso_extra_attributes  or "None")
+
+        if not sso_extra_attributes:
+            return
+
+        extra_attributes = sso_extra_attributes.extra_attributes
+        oidc_email = extra_attributes.get('oidc_email', None)
+        current_threepid_email = extra_attributes.get('current_threepid_email', None)
+        if(current_threepid_email and oidc_email and current_threepid_email != oidc_email):
+            # make the substitution
+            await self.substitute_threepid(user_id, current_threepid_email, oidc_email)
 
     async def substitute_threepid(self,user_id, current_threepid_email, new_threepid_email) -> None:
         """

--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -1,0 +1,45 @@
+
+import logging
+from typing import Any, Dict, List, Union
+
+from synapse.module_api import ModuleApi
+
+
+logger = logging.getLogger(__name__)
+
+class LoginListener(object):
+    """Implementation of the 
+    """
+
+    def __init__(
+            self,
+            config: Any,
+            api: ModuleApi,
+        ):
+
+        self.config = config
+        self.module_api = api
+
+        self.module_api.register_account_validity_callbacks(
+            on_user_login=self.on_user_login,
+        )
+
+    async def on_user_login(
+            self, 
+            user_id: str, 
+            auth_provider_type: str, 
+            auth_provider_id: str
+    ) -> None:
+        logger.info("onLogin callback %s, %s, %s", user_id, auth_provider_type, auth_provider_id)
+
+        extra_attributes = self.module_api._auth_handler._extra_attributes[user_id]
+        logger.info("extra attributes found for user %s : %s",user_id, extra_attributes or "nothing")
+
+        if auth_provider_id == "proconnect" and extra_attributes:
+            #check if extra attributes were attached to user_id 
+            extra_attributes = self.module_api._auth_handler._extra_attributes[user_id]
+            old_email = extra_attributes.get('old_email', None)
+            new_email = extra_attributes.get('new_email', None)
+            if(old_email and new_email):
+                #make the remplacement
+                logger.info("User is connected via %s with a new email:%s, the old one:%s will be substituted", auth_provider_id, new_email,old_email)

--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -28,8 +28,8 @@ class LoginCallback(object):
     async def on_user_login(
             self, 
             user_id: str, 
-            auth_provider_type: str, 
-            auth_provider_id: str
+            auth_provider_type:  str | None, 
+            auth_provider_id:  str | None
     ) -> None:
         logger.info("onLogin callback %s, %s, %s", user_id, auth_provider_type, auth_provider_id)
 
@@ -56,7 +56,11 @@ class LoginCallback(object):
             # make the substitution
             await self.substitute_threepid(user_id, current_threepid_email, oidc_email)
 
-    async def substitute_threepid(self,user_id, current_threepid_email, new_threepid_email) -> None:
+    async def substitute_threepid(
+            self, 
+            user_id:str, 
+            current_threepid_email:str, 
+            new_threepid_email:str) -> None:
         """
             Delete current threepid email and add a new threepid in synapse and sydent
         """

--- a/synapse_sso_proconnect/__init__.py
+++ b/synapse_sso_proconnect/__init__.py
@@ -38,8 +38,8 @@ class LoginListener(object):
         if auth_provider_id == "proconnect" and extra_attributes:
             #check if extra attributes were attached to user_id 
             extra_attributes = self.module_api._auth_handler._extra_attributes[user_id]
-            old_email = extra_attributes.get('old_email', None)
-            new_email = extra_attributes.get('new_email', None)
-            if(old_email and new_email):
+            oidc_email = extra_attributes.get('oidc_email', None)
+            known_email = extra_attributes.get('known_email', None)
+            if(known_email and oidc_email):
                 #make the remplacement
-                logger.info("User is connected via %s with a new email:%s, the old one:%s will be substituted", auth_provider_id, new_email,old_email)
+                logger.info("User is connected via %s with a new email:%s, the old one:%s will be substituted", auth_provider_id, oidc_email,known_email)

--- a/synapse_sso_proconnect/proconnect_mapping.py
+++ b/synapse_sso_proconnect/proconnect_mapping.py
@@ -90,6 +90,13 @@ class ProConnectMappingProvider(OidcMappingProvider[ProConnectMappingConfig]):
             display_name=display_name,
         )
     
+    async def get_extra_attributes(self, userinfo, token) -> JsonDict:
+        if(self.old_email and self.new_email):
+            return {"old_email":self.old_email, "new_email":self.new_email}
+        else:
+            return {"old_email":"default", "new_email":"default"}
+
+
     # Search user ID by its email, retrying with replacements if necessary.
     async def search_user_id_by_threepid(self, email: str)-> str | None:
         # Try to find the user ID using the provided email
@@ -110,6 +117,8 @@ class ProConnectMappingProvider(OidcMappingProvider[ProConnectMappingConfig]):
 
                     # Stop if a userId is found
                     if userId:
+                        self.old_email = replaced_email
+                        self.new_email = email
                         break
 
         return userId

--- a/synapse_sso_proconnect/proconnect_mapping.py
+++ b/synapse_sso_proconnect/proconnect_mapping.py
@@ -47,7 +47,7 @@ class ProConnectMappingProvider(OidcMappingProvider[ProConnectMappingConfig]):
             if user_info and not user_info.is_deactivated:
                 localpart = user_info.user_id.localpart
 
-        # If user has not been mapped, create a new localpart
+        # If user has not been mapped, define a localpart to create a new user
         if not localpart:
             if not await self.module_api._password_auth_provider.is_3pid_allowed(
                 "email", userinfo.email, True

--- a/synapse_sso_proconnect/proconnect_mapping.py
+++ b/synapse_sso_proconnect/proconnect_mapping.py
@@ -91,7 +91,7 @@ class ProConnectMappingProvider(OidcMappingProvider[ProConnectMappingConfig]):
             display_name=display_name,
         )
     
-    async def get_extra_attributes(self, userinfo, token) -> JsonDict:
+    async def get_extra_attributes(self, userinfo: UserInfo, token: Token) -> JsonDict:
         oidc_email = userinfo.email
         _, current_threepid_email = await self.search_user_id_by_threepid(oidc_email)
         return {"current_threepid_email":current_threepid_email, "oidc_email":oidc_email}

--- a/synapse_sso_proconnect/proconnect_mapping.py
+++ b/synapse_sso_proconnect/proconnect_mapping.py
@@ -2,7 +2,7 @@ import string
 
 import attr
 from authlib.oidc.core import UserInfo  # type: ignore
-from typing import Any, Dict, List
+from typing import Any, Dict, List, JsonDict
 
 from synapse.handlers.oidc import OidcMappingProvider, Token, UserAttributeDict
 from synapse.handlers.sso import MappingException

--- a/synapse_sso_proconnect/proconnect_mapping.py
+++ b/synapse_sso_proconnect/proconnect_mapping.py
@@ -2,8 +2,9 @@ import string
 
 import attr
 from authlib.oidc.core import UserInfo  # type: ignore
-from typing import Any, Dict, List, JsonDict
+from typing import Any, Dict, List
 
+from synapse.types import JsonDict
 from synapse.handlers.oidc import OidcMappingProvider, Token, UserAttributeDict
 from synapse.handlers.sso import MappingException
 from synapse.module_api import ModuleApi

--- a/tests/test_proconnect_mapping.py
+++ b/tests/test_proconnect_mapping.py
@@ -31,12 +31,13 @@ class ProConnectMappingTest(aiounittest.AsyncTestCase):
                 { "match":"new.fr","search":"beta.fr"}
             ]}) 
         # Call the tested function with an email that requires replacement
-        user_id = await self.module.search_user_id_by_threepid("test@new.fr")   
+        user_id, known_email = await self.module.search_user_id_by_threepid("test@new.fr")   
 
         # Assertions
         self.module.module_api._store.get_user_id_by_threepid.assert_any_call("email", "test@new.fr")
         self.module.module_api._store.get_user_id_by_threepid.assert_any_call("email", "test@beta.fr")    
-        self.assertEqual(user_id, "@test:beta")  # Should match the replaced email
+        self.assertEqual(user_id, "@test:beta") 
+        self.assertEqual(known_email, "test@beta.fr")
         
 
     async def test_search_user_id_replace_by_priority(self):        
@@ -46,18 +47,19 @@ class ProConnectMappingTest(aiounittest.AsyncTestCase):
             ]}) #replace by domain leads to a dead-end but it lower in the list
         
         # Call the tested function with an email that requires replacement
-        user_id = await self.module.search_user_id_by_threepid("test@new.fr")   
+        user_id, known_email = await self.module.search_user_id_by_threepid("test@new.fr")   
         # Assertions
         self.module.module_api._store.get_user_id_by_threepid.assert_any_call("email", "test@new.fr")
         self.module.module_api._store.get_user_id_by_threepid.assert_any_call("email", "test@old.fr")    
         self.assertEqual(user_id, "@test:old")  # Should match the replaced email
+        self.assertEqual(known_email, "test@old.fr")
 
     async def test_search_user_id_with_empty_map(self):
 
         self.module = create_module({"user_id_lookup_fallback_rules":[]})
 
-        # Call the tested function with an email that requires replacement
-        user_id = await self.module.search_user_id_by_threepid("test@numerique.fr")
+        user_id, known_email = await self.module.search_user_id_by_threepid("test@numerique.fr")
 
         # Assertions
         self.assertEqual(user_id, "@test:numerique")
+        self.assertEqual(known_email, "test@numerique.fr")


### PR DESCRIPTION
Test 1  
- having a account xxxx@gmail.com
- having a fallback rule de yopmail -> gmail
- proconnect with xxxx@yopmail.com
-> login is successful
-> 3PID is updated to xxxx@yopmail.com

Test 2
- having a account yyyy@gmail.com
- proconnect with yyyy@gmail.com
-> login is successful
-> no 3PID stuff

Test 3 (how to test?)
- having a account yyyy@gmail.com
- proconnect with yyyy@gmail.com
- change email in pronnect for user
- proconnect with zzzz@gmail.com
-> login is successful
-> no 3PID stuff
